### PR TITLE
Clean up async code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  }
+}

--- a/README.md
+++ b/README.md
@@ -46,4 +46,6 @@ Now you should be able to run the full process:
 npm run harvest:groups | tee harvest_groups.out
 
 npm run harvest:events | tee harvest_events.out
+
+npm run harvest:events:worker | tee harvest_events_worker.out
 ```

--- a/src/tasks/harvest_events.js
+++ b/src/tasks/harvest_events.js
@@ -42,7 +42,7 @@ async function harvest () {
       return workQueue.add(jobDetails, { delay: currentDelay, removeOnComplete: true, attempts: 3 })
     })
 
-    Promise.all(allJobs)
+    await Promise.all(allJobs)
       .then(allJobResults => {
         console.log('Number of added Jobs:', allJobResults.length)
       })


### PR DESCRIPTION
Some of these promises were not being handled/returned/captured, which meant errors could escape, and jobs would call back before they were really finished (perhaps leading to more parallelism than intended).

You can read the step-by-step refactoring in #20. But this branch jumps to the final result: a refactor to use async-await, which is flatter and cleaner, and makes it easier to correctly handle promises without boilerplate.

I also opted to change some of the loops from parallel to series.