### PR TITLE
Blacklist some undesirable groups

### DIFF
--- a/src/services/meetup_service.js
+++ b/src/services/meetup_service.js
@@ -83,6 +83,8 @@ class MeetupService {
   }
 
   static isLegit (group) {
+    if (MeetupService.BLACKLIST_GROUPS.includes(group.link)) { return false }
+
     const { name } = group
     const tokens = name.split(' ')
 
@@ -110,6 +112,16 @@ class MeetupService {
     })
 
     return this.axios[type]
+  }
+
+  static get BLACKLIST_GROUPS () {
+    return [
+      // Not tech related
+      'https://www.meetup.com/Kakis-SG-Anything-Watever-Meetup-Group/',
+      'https://www.meetup.com/Wireless-devices-and-your-health/',
+      // I find this one a bit spammy, feels like a marketing drive
+      'https://www.meetup.com/A-US-stock-market-listedCo-Big-Data-AI-New-Technology/'
+    ]
   }
 
   static get BLACKLIST_TOKENS () {


### PR DESCRIPTION
This takes the two filters William added to telegram_worker, and moves them upstream into MeetupService (and adds one more group to the blacklist).

(I have not removed William's downstream filter because I would also need to remove his tests, which feels really mean!)

Pros:

- By maintaining a blacklist in the git repository, we can collaborate on the lists, and document (comment) why each group was removed.

Cons:

- Now that I better understand this application, it seems the usual flow would be for an admin (Michael?) to blacklist these three groups, by hitting the endpoint `/:platform/:urlname/blacklist`, because this _also updates the events_ already in the DB.