### PR TITLE
Reuse existing access token

### DIFF
--- a/src/services/harvesters/meetup_harvester.js
+++ b/src/services/harvesters/meetup_harvester.js
@@ -43,7 +43,7 @@ class MeetupHarvester {
       })
 
       if (groupsResponse.status === 200) {
-        console.log('Rate Limit Remaining:', groupsResponse.headers['x-ratelimit-remaining'])
+        console.log('[API] Rate Limit Remaining:', groupsResponse.headers['x-ratelimit-remaining'])
         const groups = groupsResponse.data
 
         allGroups.push(...groups)
@@ -74,7 +74,7 @@ class MeetupHarvester {
       })
 
       if (groupsEventsResponse.status === 200) {
-        console.log('Rate Limit Remaining:', groupsEventsResponse.headers['x-ratelimit-remaining'])
+        console.log('[API] Rate Limit Remaining:', groupsEventsResponse.headers['x-ratelimit-remaining'])
         const groups = groupsEventsResponse.data
 
         allEvents.push(...groups)

--- a/src/services/harvesters/meetup_harvester.js
+++ b/src/services/harvesters/meetup_harvester.js
@@ -18,11 +18,16 @@ class MeetupHarvester {
       }
 
       const newTokenResponse = await this.meetupService.refreshToken(this.refreshToken)
-      if (!newTokenResponse) {
-        throw new Error('Unable to refresh token')
+      if (newTokenResponse === false) {
+        // Keep using the current token
+        return
+      }
+      if (!newTokenResponse || newTokenResponse.error) {
+        throw new Error(`Unable to refresh token`)
       }
       const newAccessToken = newTokenResponse.access_token
-      this.meetupService.setAccessToken(newAccessToken)
+      const expiresIn = newTokenResponse.expires_in
+      this.meetupService.setAccessToken(newAccessToken, expiresIn)
     } catch (err) {
       console.log('Prepare Service Error', err)
       Sentry.captureException(err)

--- a/src/services/harvesters/meetup_harvester.js
+++ b/src/services/harvesters/meetup_harvester.js
@@ -10,10 +10,12 @@ class MeetupHarvester {
 
   async prepareService () {
     try {
-      this.meetupService = new MeetupService({
-        consumerKey: this.consumerKey,
-        consumerSecret: this.consumerSecret
-      })
+      if (!this.meetupService) {
+        this.meetupService = new MeetupService({
+          consumerKey: this.consumerKey,
+          consumerSecret: this.consumerSecret
+        })
+      }
 
       const newTokenResponse = await this.meetupService.refreshToken(this.refreshToken)
       if (!newTokenResponse) {

--- a/src/services/meetup_service.js
+++ b/src/services/meetup_service.js
@@ -34,12 +34,15 @@ class MeetupService {
         }
       ))
 
+      console.log(`[API] POST /oauth2/access <authorization_code> (status ${response.status})`)
+
       if (response.status === 200) {
         return response.data
       } else {
         return { error: 'Invalid response' }
       }
     } catch (err) {
+      console.error(`[API] POST /oauth2/access <authorization_code> error: ${err}`)
       Sentry.captureException(err)
       return { error: err.message }
     }
@@ -56,12 +59,15 @@ class MeetupService {
         }
       ))
 
+      console.log(`[API] POST /oauth2/access <refresh_token> (status ${response.status})`)
+
       if (response.status === 200) {
         return response.data
       } else {
         return { error: 'Invalid response' }
       }
     } catch (err) {
+      console.error(`[API] POST /oauth2/access <refresh_token> error: ${err}`)
       Sentry.captureException(err)
       return { error: err.message }
     }
@@ -71,12 +77,15 @@ class MeetupService {
     try {
       const response = await this.axiosInstance('api').get(uri, { params: data })
 
+      console.log(`[API] GET ${uri} ${JSON.stringify(data)} (status ${response.status}, size ${response.headers['content-length']})`)
+
       if (response.status === 200) {
         return response
       } else {
         return { error: 'Invalid response' }
       }
     } catch (err) {
+      console.error(`[API] GET ${uri} ${JSON.stringify(data)} error: ${err}`)
       Sentry.captureException(err)
       return { error: err.message }
     }

--- a/src/services/meetup_service.js
+++ b/src/services/meetup_service.js
@@ -11,14 +11,16 @@ class MeetupService {
     this.consumerSecret = options.consumerSecret
     this.redirectUri = options.redirectUri
     this.accessToken = null
+    this.accessTokenExpiryTime = null
   }
 
   authorizeLink () {
     return `${this.authDomain}/oauth2/authorize?client_id=${this.consumerKey}&response_type=code&redirect_uri=${this.redirectUri}`
   }
 
-  setAccessToken (newToken) {
+  setAccessToken (newToken, expiresIn) {
     this.accessToken = newToken
+    this.accessTokenExpiryTime = Date.now() + 1000 * expiresIn * 0.9
     this.axiosInstance('api').defaults.headers.common['Authorization'] = `Bearer ${this.accessToken}`
   }
 
@@ -49,6 +51,11 @@ class MeetupService {
   }
 
   async refreshToken (refreshCode) {
+    if (Date.now() < this.accessTokenExpiryTime) {
+      console.log(`The current token is still valid`)
+      return false
+    }
+
     try {
       const response = await this.axiosInstance('auth').post('/oauth2/access', querystring.stringify(
         {

--- a/src/services/meetup_service.test.js
+++ b/src/services/meetup_service.test.js
@@ -97,7 +97,7 @@ describe('MeetupService', () => {
         is_pro_admin: false
       })
 
-    service.setAccessToken(newToken)
+    service.setAccessToken(newToken, 3600)
     const result = await service.fetchApi('/members/self')
 
     expect(result.data.name).toEqual('Michael Cheng')


### PR DESCRIPTION
Logging shows that we are currently calling Meetup's `/oauth2/access <refresh_token>` once before every API request in `harvest_event_worker.js`. That seems to me like overkill!

This code will check if the current access token is still valid (within date), and if so then it will skip the refresh request, and just keep reusing the existing token.

(It also skips creating a new meetupService if we already have one. Because a new meetupService will never have a token to reuse.)