### PR TITLE
[QUESTIONABLE] Reduce parallelism to 1 job per worker

### DIFF
--- a/src/tasks/harvest_event_worker.js
+++ b/src/tasks/harvest_event_worker.js
@@ -11,7 +11,7 @@ const Queue = require('bull')
 const REDIS_URL = process.env.REDIS_URL || 'redis://127.0.0.1:6379'
 
 const workers = process.env.WEB_CONCURRENCY || 1
-const maxJobsPerWorker = 20
+const maxJobsPerWorker = 1
 
 const db = require('../models/index')
 
@@ -34,6 +34,22 @@ function start () {
   workQueue.process(maxJobsPerWorker, async (job, done) => {
     try {
       const allGroupEvents = []
+
+      // This code doesn't seem quite right, because all jobs share one
+      // harvester. (Workers fork into separate processes, but jobs do not.)
+      //
+      // So when maxJobsPerWorker = 20, then 20 jobs will call
+      // harvester.prepareService() in parallel, all on the same harvester!
+      //
+      // And then they will call harvester.fetchGroupEvents() all on the same
+      // harvester, all now using the same access token (the last one
+      // generated)!
+      //
+      // We could move the harvester constructor inside this function, but even
+      // then my rate limit was dropping too quickly.
+      //
+      // So I dropped maxJobsPerWorker to 1.
+      //
       await harvester.prepareService()
 
       Promise.all([harvester.fetchGroupEvents(job.data)])


### PR DESCRIPTION
I had problems with the rate limiter when harvest_event_worker ran 20 jobs in parallel. (Eventually leading to error code 429 aka "Too Many Requests".)

Aren't you getting this problem in production? I am getting it consistently.

So I reduced the concurrency to 1. After that the rate limiter logs dropped from 29 to 19, and then back up to 29 again. 👍

(Although I'm not actually sure what it causing the nice gentle rate now, because I don't seen any delay code. Perhaps we should add some, to _ensure_ that we are delaying between requests!)