### PR TITLE
[BAD PR] Re-apply filters when harvesting

### DIFF
--- a/src/routes/groups.js
+++ b/src/routes/groups.js
@@ -15,13 +15,15 @@ async function fetchGroup (platform, urlname) {
     })
 }
 
-async function blackListGroup (group) {
+async function blackListGroup (group, newState) {
   await group.update({
-    blacklisted: true
+    blacklisted: newState
   })
 
+  const shouldBeActive = !newState
+
   return db.sequelize.query(
-    'UPDATE "Events" SET active = false WHERE platform = ? AND group_id = ?',
+    `UPDATE "Events" SET active = ${shouldBeActive} WHERE platform = ? AND group_id = ?`,
     {
       replacements: [group.platform, group.platform_identifier],
       type: db.sequelize.QueryTypes.UPDATE
@@ -56,7 +58,7 @@ router.delete('/:platform/:urlname/blacklist', checkAdminToken, async function (
     const { platform, urlname } = req.params
     const group = await fetchGroup(platform, urlname)
 
-    const result = await blackListGroup(group)
+    const result = await blackListGroup(group, true)
 
     res.json(result)
   } catch (err) {
@@ -65,3 +67,5 @@ router.delete('/:platform/:urlname/blacklist', checkAdminToken, async function (
 })
 
 module.exports = router
+
+module.exports.blackListGroup = blackListGroup

--- a/src/services/meetup_service.js
+++ b/src/services/meetup_service.js
@@ -83,6 +83,9 @@ class MeetupService {
   }
 
   static isLegit (group) {
+    // NOTE: This function may be given a group from the meetup API (above), or
+    // a group from our DB (in removeUnwatedGroups), so beware the differences.
+
     const { name } = group
     const tokens = name.split(' ')
 

--- a/src/tasks/harvest_event_worker.js
+++ b/src/tasks/harvest_event_worker.js
@@ -20,6 +20,53 @@ const moment = require('moment-timezone')
 
 const htmlToText = require('html-to-text')
 
+// A bit of a hack, to ensure checkExistingEvents() only runs once, not in every worker
+const isRootWorker = !process.env.CHILD_WORKER
+// Let any processes forked from this one know that they are children
+process.env.CHILD_WORKER = 'true'
+
+async function checkExistingEvents () {
+  if (!isRootWorker) {
+    return
+  }
+
+  console.log('Checking for any unwanted events')
+
+  // We need to find all events whose group has been removed from the Groups table.
+  //   SELECT * from Events e WHERE e.group_id NOT IN (SELECT platform_identifier from public."Groups");
+  // But I couldn't work out how to execute that through Sequelize.
+  // So instead I fetch everything in JavaScript, and then process it.
+  //
+  // I also implement an additional rule: Remove events whose group.blacklisted === true
+
+  const allGroups = await db.Group.findAll({})
+  const groupsById = {}
+  allGroups.forEach(group => {
+    groupsById[group.platform_identifier] = group
+  })
+
+  const allEvents = await db.Event.findAll({
+    attributes: ['id', 'name', 'group_id', 'group_name', 'active']
+  })
+
+  const isLegitEvent = (event) => {
+    const group = groupsById[event.group_id]
+    const isOrphaned = !group
+    const isBlacklisted = group && group.blacklisted
+    return !isOrphaned && !isBlacklisted
+  }
+
+  for (const event of allEvents) {
+    const shouldBeActive = isLegitEvent(event)
+    if (event.active !== shouldBeActive) {
+      console.log(`Changing active status of event '${event.name}' to: '${shouldBeActive}'`)
+      await event.update({
+        active: shouldBeActive
+      })
+    }
+  }
+}
+
 function start () {
   const harvester = new HarvesterService({
     meetup: {
@@ -103,4 +150,9 @@ function start () {
   })
 }
 
-throng({ workers, start })
+checkExistingEvents().then(() => {
+  throng({ workers, start })
+}).catch(err => {
+  console.log('Main Harvester Error:', err)
+  Sentry.captureException(err)
+})


### PR DESCRIPTION
I'm guessing you won't want this. I wrote it before I discovered there was a `/:platform/:urlname/blacklist` route.

It basically forcibly applies the blacklisting filters of all groups and events whenever we harvest. It was useful when I was testing the blacklisting filters.

Pros:

- If we change the blacklist filters in MeetupService, then they will be applied to existing DB data, the next time we harvest.

  That means unwanted events which were appearing on the events list, will not be hidden.

Cons:

- It considers the filters in MeetupService to be the _single source of truth_.

  So if you have manually blacklisted a group using the aforementioned route, but it is not caught by the filters, then that group will reappear!

  (And I'm guessing you have manually blacklisted quite a few groups in the past.)

You may close this PR. I'm just sharing it because of all the code I wrote. 😛