### PR TITLE
[low priority] Various

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
     ```
 ### Set up your meetup credentials
 
-To pull data from Meetup, you first need to register as a Meetup API consumer:
+To pull data from Meetup, you first need to register as a Meetup API consumer. You can read the full [documentation here](https://www.meetup.com/meetup_api/auth/) but here is the setup process:
 
 1. Visit https://secure.meetup.com/meetup_api/oauth_consumers/ and (if you don't already have a consumer) hit [Create New Consumer]
 
@@ -49,3 +49,11 @@ npm run harvest:events | tee harvest_events.out
 
 npm run harvest:events:worker | tee harvest_events_worker.out
 ```
+
+### Remove unwanted groups from the listing
+
+If there are groups appearing in the events list which you think do not belong, you can add them to the blacklist at the bottom of `meetup_service.js`.
+
+You may like to attach a comment, so that other devs understand why you removed that group, and can check in future whether the decision should still apply.
+
+Then please open up a pull request with your added filters. Thanks!

--- a/src/services/harvester_service.js
+++ b/src/services/harvester_service.js
@@ -8,8 +8,10 @@ class HarvesterService {
 
   async prepareService () {
     try {
-      this.meetupHarvester = new MeetupHarvester(this.meetup)
-      await this.meetupHarvester.prepareService()
+      if (!this.meetupHarvester) {
+        this.meetupHarvester = new MeetupHarvester(this.meetup)
+        await this.meetupHarvester.prepareService()
+      }
     } catch (err) {
       console.log('Prepare Service Error', err)
       Sentry.captureException(err)

--- a/src/services/meetup_service.js
+++ b/src/services/meetup_service.js
@@ -99,8 +99,9 @@ class MeetupService {
   }
 
   static isLegit (group) {
-    // NOTE: This function may be given a group from the meetup API (above), or
-    // a group from our DB (in removeUnwatedGroups), so beware the differences.
+    // NOTE: This function may be given a group from the meetup API (in
+    // harvest_groups.js), or a group from our DB (in checkExistingEvents), so
+    // beware the differences.
 
     if (MeetupService.BLACKLIST_GROUPS.includes(group.link)) { return false }
 

--- a/src/services/meetup_service.js
+++ b/src/services/meetup_service.js
@@ -103,6 +103,8 @@ class MeetupService {
     // harvest_groups.js), or a group from our DB (in checkExistingEvents), so
     // beware the differences.
 
+    if (MeetupService.WHITELIST_GROUPS.includes(group.link)) { return true }
+
     if (MeetupService.BLACKLIST_GROUPS.includes(group.link)) { return false }
 
     const { name } = group
@@ -134,7 +136,22 @@ class MeetupService {
     return this.axios[type]
   }
 
+  static get BLACKLIST_TOKENS () {
+    return ['ethereum', 'blockchain', 'bitcoin', 'ico', 'ledger', 'crypto', 'cryptocurrency', 'money', 'gold', 'token',
+      'business', 'enterprise', 'entrepreneur', 'entrepreneurship', 'executive', 'founder', 'investor', 'skillsfuture']
+  }
+
+  static get WHITELIST_GROUPS () {
+    // For groups which were caught by the filters, but might actually be interesting for developers
+    return [
+      // This group hosted Brendan's excellent DApps Dev Club in 2019, which taught developers the basics of Solidity
+      // However it looks like some of their meetings have been less code-oriented, so I'm not whitelisting it right now
+      // 'https://www.meetup.com/BlockChain-Dapps-Technology'
+    ]
+  }
+
   static get BLACKLIST_GROUPS () {
+    // For groups which we don't want to show, but which weren't caught by the filters
     return [
       // Not tech related
       'https://www.meetup.com/Kakis-SG-Anything-Watever-Meetup-Group/',
@@ -142,11 +159,6 @@ class MeetupService {
       // I find this one a bit spammy, feels like a marketing drive
       'https://www.meetup.com/A-US-stock-market-listedCo-Big-Data-AI-New-Technology/'
     ]
-  }
-
-  static get BLACKLIST_TOKENS () {
-    return ['ethereum', 'blockchain', 'bitcoin', 'ico', 'ledger', 'crypto', 'cryptocurrency', 'money', 'gold', 'token',
-      'business', 'enterprise', 'entrepreneur', 'entrepreneurship', 'executive', 'founder', 'investor', 'skillsfuture']
   }
 }
 

--- a/src/tasks/harvest_event_worker.js
+++ b/src/tasks/harvest_event_worker.js
@@ -10,7 +10,11 @@ const throng = require('throng')
 const Queue = require('bull')
 const REDIS_URL = process.env.REDIS_URL || 'redis://127.0.0.1:6379'
 
+// Warning: If I set this above 1, I see a lot of "401 Unauthorized" reponses.
+// I think this is because each worker requests a separate access token, but only the last requested token is valid.
 const workers = process.env.WEB_CONCURRENCY || 1
+
+// I don't recommend setting this above 8.  Their rate limiter might kick in before ours, resulting in jobs that run but don't succeed.
 const maxJobsPerWorker = 1
 
 const db = require('../models/index')


### PR DESCRIPTION
No rush. This PR includes:

- Some docs and comments

- A fix for the `reuse-existing-token` branch

- Added a whitelist, for any groups which were hidden by the token heuristics but which should actually be displayed

- Automatically slow down processing when we detect rate limit is dropping

  With that, we can now safely increase `maxJobsPerWorker` to 4 (probably even to 8). But until that is actually needed, I prefer the linear logging!