### PR TITLE
Blacklist two groups spamming python crash courses

### DIFF
--- a/src/services/meetup_service.js
+++ b/src/services/meetup_service.js
@@ -175,7 +175,10 @@ class MeetupService {
       'https://www.meetup.com/Kakis-SG-Anything-Watever-Meetup-Group/',
       'https://www.meetup.com/Wireless-devices-and-your-health/',
       // I find this one a bit spammy, feels like a marketing drive
-      'https://www.meetup.com/A-US-stock-market-listedCo-Big-Data-AI-New-Technology/'
+      'https://www.meetup.com/A-US-stock-market-listedCo-Big-Data-AI-New-Technology/',
+      // Cheap python courses ("crash course" and "full course"). Might be useful for new developers, but they are flooding our events list, and always the same thing!
+      'https://www.meetup.com/Data-Science-and-Machine-Learning-University/',
+      'https://www.meetup.com/Teach-Code-for-Everyone/'
     ]
   }
 }


### PR DESCRIPTION
Nothing especially against these groups, except:

- They have 8 events a week, and they are always the same thing (Python crash course, Python full course)

- As a result, they are flooding the events list, and reducing the quality

I'm open to other suggestions. But simply adding them to the blacklist was the quickest and easiest solution.