### PR TITLE
Cleanup some unwanted events

### DIFF
--- a/src/services/meetup_service.js
+++ b/src/services/meetup_service.js
@@ -178,7 +178,9 @@ class MeetupService {
       'https://www.meetup.com/A-US-stock-market-listedCo-Big-Data-AI-New-Technology/',
       // Cheap python courses ("crash course" and "full course"). Might be useful for new developers, but they are flooding our events list, and always the same thing!
       'https://www.meetup.com/Data-Science-and-Machine-Learning-University/',
-      'https://www.meetup.com/Teach-Code-for-Everyone/'
+      'https://www.meetup.com/Teach-Code-for-Everyone/',
+      // A bit spammy
+      'https://www.meetup.com/get-a-software-job-learn-coding-for-non-computer-sci-majors/'
     ]
   }
 }

--- a/src/tasks/harvest_event_worker.js
+++ b/src/tasks/harvest_event_worker.js
@@ -62,12 +62,9 @@ async function checkExistingEvents () {
 
   for (const event of allEvents) {
     const shouldBeActive = isLegitEvent(event)
-    // This would activate all DB events where the group they belong to is legitimate. But it doesn't check if the event is still visible on meetup.com.
-    // But we don't really need to re-activate inactive events here. That can be done later, when we actually fetch the event.
-    // if (event.active !== shouldBeActive) {
-
-    // We deactivate events from groups which have disappeared or been blacklisted
-    if (!shouldBeActive && event.active) {
+    // We deactivate events from groups which have disappeared or been blacklisted.
+    // We don't activate events here.  That is done later, when the events are harvested.
+    if (event.active && !shouldBeActive) {
       console.log(`Changing active status of event from ${event.active} to ${shouldBeActive}: '${event.url}'`)
       await event.update({
         active: shouldBeActive

--- a/src/tasks/harvest_event_worker.js
+++ b/src/tasks/harvest_event_worker.js
@@ -62,7 +62,12 @@ async function checkExistingEvents () {
 
   for (const event of allEvents) {
     const shouldBeActive = isLegitEvent(event)
-    if (event.active !== shouldBeActive) {
+    // This would activate all DB events where the group they belong to is legitimate. But it doesn't check if the event is still visible on meetup.com.
+    // But we don't really need to re-activate inactive events here. That can be done later, when we actually fetch the event.
+    // if (event.active !== shouldBeActive) {
+
+    // We deactivate events from groups which have disappeared or been blacklisted
+    if (!shouldBeActive && event.active) {
       console.log(`Changing active status of event from ${event.active} to ${shouldBeActive}: '${event.url}'`)
       await event.update({
         active: shouldBeActive


### PR DESCRIPTION
The previous code would temporarily activate all events in a known group, regardless whether those events are actually visible on the Meetup site.

But if for some reason the group is not scanned later, that would leave those events visible. (I'm not sure why but it appeared the scanning [wasn't happening](https://github.com/engineersftw/events-api/issues/49).)

This new code will no longer activate events at the start of the run. It will leave the activation to the later harvesting code.

However it will continue with the important task of deactivating events which belong to orphaned or blacklisted groups.

----

I have also blacklisted a group which has posted lots of events, and then removed them.

(Although this group wouldn't be a problem if our aggregator was working properly. So we may still want to investigate that!)