### PR TITLE
Move checkExistingEvents() out of worker script

### DIFF
--- a/src/tasks/harvest_event_worker.js
+++ b/src/tasks/harvest_event_worker.js
@@ -24,55 +24,6 @@ const moment = require('moment-timezone')
 
 const htmlToText = require('html-to-text')
 
-// A bit of a hack, to ensure checkExistingEvents() only runs once, not in every worker
-const isRootWorker = !process.env.CHILD_WORKER
-// Let any processes forked from this one know that they are children
-process.env.CHILD_WORKER = 'true'
-
-async function checkExistingEvents () {
-  if (!isRootWorker) {
-    return
-  }
-
-  console.log('Checking for any unwanted events')
-
-  // We need to find all events whose group has been removed from the Groups table.
-  //   SELECT * from Events e WHERE e.group_id NOT IN (SELECT platform_identifier from public."Groups");
-  // But I couldn't work out how to execute that through Sequelize.
-  // So instead I fetch everything in JavaScript, and then process it.
-  //
-  // I also implement an additional rule: Remove events whose group.blacklisted === true
-
-  const allGroups = await db.Group.findAll({})
-  const groupsById = {}
-  allGroups.forEach(group => {
-    groupsById[group.platform_identifier] = group
-  })
-
-  const allEvents = await db.Event.findAll({
-    attributes: ['id', 'name', 'url', 'group_id', 'group_name', 'active']
-  })
-
-  const isLegitEvent = (event) => {
-    const group = groupsById[event.group_id]
-    const isOrphaned = !group
-    const isBlacklisted = group && group.blacklisted
-    return !isOrphaned && !isBlacklisted
-  }
-
-  for (const event of allEvents) {
-    const shouldBeActive = isLegitEvent(event)
-    // We deactivate events from groups which have disappeared or been blacklisted.
-    // We don't activate events here.  That is done later, when the events are harvested.
-    if (event.active && !shouldBeActive) {
-      console.log(`Changing active status of event from ${event.active} to ${shouldBeActive}: '${event.url}'`)
-      await event.update({
-        active: shouldBeActive
-      })
-    }
-  }
-}
-
 async function deactivateHiddenEvents (groupId, allGroupEvents) {
   // Look for upcoming events for this group in the DB which are no longer
   // present in the list provided by meetup, and set them as hidden.
@@ -199,9 +150,4 @@ function start () {
   })
 }
 
-checkExistingEvents().then(() => {
-  throng({ workers, start })
-}).catch(err => {
-  console.log('Main Harvester Error:', err)
-  Sentry.captureException(err)
-})
+throng({ workers, start })


### PR DESCRIPTION
_This builds on top of PR #50 so you may want to review that one first._

This PR simply moves the `checkExistingEvents()` function from the start of `harvest_event_worker.js` to the end of `harvest_events.js`

Is `harvest_event_worker.js` run often, or is it run only once and it picks up tasks when they are added?

- If `harvest_event_worker.js` is restarted regularly then this PR is not really needed.

- But if `harvest_event_worker.js` is like a service or daemon which stays running and is rarely restarted, then this PR is necessary.

  It's better to have this code in a script that runs more often!

Tested on local, executing without issue.